### PR TITLE
Preserve context when invoking hooks/tests

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -48,15 +48,15 @@
         suites[0][methodName](fn);
       } else {
         suites[0][methodName](function(d) {
-          invoke(fn, d);
+          invoke(this, fn, d);
         });
       }
     };
   }
 
-  function invoke(fn, d) {
+  function invoke(context, fn, d) {
     done = d;
-    fn();
+    fn.call(context);
     if (!isAsync) {
       done = null;
       d();
@@ -98,7 +98,7 @@
           test = new Mocha.Test(title, fn);
         } else {
           var method = function(d) {
-            invoke(fn, d);
+            invoke(this, fn, d);
           };
           method.toString = function() {
             return fn.toString();


### PR DESCRIPTION
This allows attaching test-related objects to the mocha test context, e.g. stubs, mock servers, etc. (mostly used in unit tests).

``` javascript
describe("User export", function() {
  beforeEach(function() {
    this.sinon = sinon.sandbox.create();
    this.server = this.sinon.useFakeServer();
  });

  afterEach(function() {
    this.sinon.restore();
  });

  it("should make an AJAX request and resolve the returned promise if successful", function() {
    var spy = this.sinon.spy();
    Ember.run(this, function() {
      App.User.export.then(spy);
      this.server.respond();
    });

    expect(spy).to.have.been.called;
   });
});
```
