### PR TITLE
On asyncEnd, if done function is defined, get a local var of it

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -16,12 +16,13 @@
       clearTimeout(doneTimeout);
     },
     asyncEnd: function() {
+      var scopedDone;
       isAsync = false;
       if (done) {
+        scopedDone = done;
         doneTimeout = setTimeout(function() {
-          var d = done;
           done = null;
-          d();
+          scopedDone();
         });
       }
     },


### PR DESCRIPTION
Seems that a race condition exists where the global done var could get
set to null before the function in setTimeout gets executed. In that
case, the d var would get set to null and then would error on `d();`
