### PR TITLE
Fixed var statement typo

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -1,7 +1,7 @@
 /* Ember Mocha Adapter | (C) 2014 Teddy Zeenny | https://github.com/teddyzeenny/ember-mocha-adapter */
 
 (function() {
-  var done, doneTimeout, countAsync, emberBdd, isPromise;
+  var done, doneTimeout, isAsync, emberBdd, isPromise;
 
   done = null;
   doneTimeout = null;


### PR DESCRIPTION
The opening `var` statement declared a `countAsync` variable which is not used anywhere else in the file. But there is an `isAsync` variable set to false a few lines down, which isn't declared using `var`. I assume this is a typo (since this code fails under "use strict" with a ReferenceError), and I renamed the variable declared in `var` to `isAsync`.
