### PR TITLE
Use ember's built-in integration test promise chaining

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -72,6 +72,10 @@
     if (result && typeof result.then === 'function') {
       isPromise = true;
       result.then(function() { complete(); }, complete);
+    } else if (Ember.Test.lastPromise) {
+      // Respect the implicit promise chaining in Ember integration tests
+      isPromise = true;
+      Ember.Test.lastPromise.then(function() { complete(); }, complete);
     } else {
        if (isAsync === 0) { complete(); }
     }


### PR DESCRIPTION
Ember.Test has an implicit promise that lets users write declarative integration tests without explicitly threading the promise everywhere:

````js
  it('can visit /', function() {
    visit('/');
    andThen(function() {
      expect(currentPath()).to.equal('index');
    });
  });
````
But the above code can actually fail silently (if the route does not load instantly), because ember-mocha-adapter only waits around if the test itself returns a promise. This change makes it also check for Ember.Test's implicit promise.

The stock qunit adapter has a similar problem, but it handles late exceptions differently, which minimizes the impact.