### PR TITLE
Preserve original stack trace

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -25,14 +25,14 @@
       }
     },
     exception: function(reason) {
-      var error, d;
-
-      error = new Error(reason);
+      if (!(reason instanceof Error)) {
+        reason = new Error(reason);
+      }
       if (done) {
-        complete(error);
+        complete(reason);
       } else {
         setTimeout(function() {
-          throw error;
+          throw reason;
         });
       }
     }


### PR DESCRIPTION
Wrapping in a new Exception object causes the original stack trace to be lost.