### PR TITLE
Use Ember.run to run "invoke" methods (before|after)(Each)?

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -66,7 +66,7 @@
   function invoke(context, fn, d) {
     done = d;
     isPromise = false;
-    var result = fn.call(context);
+    var result = Ember.run(context, fn);
     // If a promise is returned,
     // complete test when promise fulfills / rejects
     if (result && typeof result.then === 'function') {


### PR DESCRIPTION
This fixes a problem where if you want to do something like

```js
afterEach(function() {
  thing.destroy();
});
```

You won't have to wrap the destroy calls, or other Ember setters/etc in `Ember.run`'s in every `before`, `after`, `beforeEach`, and `afterEach`, and anywhere we use `invoke`